### PR TITLE
Fixed GitHubRepository#getContent(String)

### DIFF
--- a/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRepository.java
+++ b/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRepository.java
@@ -1006,7 +1006,7 @@ public class GitHubRepository extends UniqueGitHubObject {
 	 */
 	@GitHubAccessPoint(path = "/contents", type = GitHubFile.class, requiresAccessToken = false)
 	public GitHubFile getContent(String path) {
-		return new GitHubFile(api, this, path);
+		return new GitHubFile(api, this, "/contents/" + path);
 	}
 
 	@GitHubAccessPoint(path = "@pushed_at", type = Date.class, requiresAccessToken = false)


### PR DESCRIPTION
I was expecting the annotation to fix the issue, but it looks like I need to append the right suffix manually.