### PR TITLE
Added API for GitHub Releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.thebusybiscuit</groupId>
     <artifactId>GitHubWebAPI4Java</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRelease.java
+++ b/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRelease.java
@@ -55,7 +55,7 @@ public class GitHubRelease extends GitHubObject {
      * @throws IllegalAccessException
      */
     @GitHubAccessPoint(path = "@prerelease", type = Boolean.class, requiresAccessToken = false)
-    public boolean isPrerelease() throws IllegalAccessException {
+    public boolean isPreRelease() throws IllegalAccessException {
         return getBoolean("prerealease", false);
     }
 

--- a/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRelease.java
+++ b/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRelease.java
@@ -1,0 +1,135 @@
+package io.github.TheBusyBiscuit.GitHubWebAPI4Java.objects.repositories;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.github.TheBusyBiscuit.GitHubWebAPI4Java.GitHubWebAPI;
+import io.github.TheBusyBiscuit.GitHubWebAPI4Java.annotations.GitHubAccessPoint;
+import io.github.TheBusyBiscuit.GitHubWebAPI4Java.objects.GitHubObject;
+import io.github.TheBusyBiscuit.GitHubWebAPI4Java.objects.users.GitHubUser;
+
+import java.util.Date;
+
+/**
+ * Represents a Release from a GitHubRepository.
+ * @since 1.3.4
+ */
+public class GitHubRelease extends GitHubObject {
+
+    public GitHubRelease(GitHubWebAPI api, GitHubObject parent, int id) {
+        super(api, parent, "/releases/" + id);
+    }
+
+    public GitHubRelease(GitHubWebAPI api, GitHubObject parent, int id, JsonElement response) {
+        super(api, parent, "/releases/" + id);
+
+        this.minimal = response;
+    }
+
+    public GitHubRelease(GitHubObject obj) {
+        super(obj);
+    }
+
+    /**
+     * Returns the ID of this release.
+     * @return the ID of this release.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@id", type = Integer.class, requiresAccessToken = false)
+    public int getID() throws IllegalAccessException {
+        return getInteger("id", false);
+    }
+
+    /**
+     * Returns whether this release is a draft (i.e. not published yet) or not.
+     * @return {@code true} if this release is a draft, {@code false} otherwise.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@draft", type = Boolean.class, requiresAccessToken = false)
+    public boolean isDraft() throws IllegalAccessException {
+        return getBoolean("draft", false);
+    }
+
+    /**
+     * Returns whether this release is indicated as a pre-release or not.
+     * @return {@code true} if this release is a pre-release, {@code false} otherwise.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@prerelease", type = Boolean.class, requiresAccessToken = false)
+    public boolean isPrerelease() throws IllegalAccessException {
+        return getBoolean("prerealease", false);
+    }
+
+    /**
+     * Returns the name of the git tag corresponding to this release.
+     * @return the name of the git tag corresponding to this release.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@tag_name", type = String.class, requiresAccessToken = false)
+    public String getTagName() throws IllegalAccessException {
+        return getString("tag_name", false);
+    }
+
+    @GitHubAccessPoint(path = "@target_commitish", type = String.class, requiresAccessToken = false)
+    public String getTargetCommitish() throws IllegalAccessException {
+        return getString("target_commitish", false);
+    }
+
+    /**
+     * Returns the name of this release.
+     * @return the name of this release.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@name", type = String.class, requiresAccessToken = false)
+    public String getName() throws IllegalAccessException {
+        return getString("name", false);
+    }
+
+    /**
+     * Returns the creation date of this release.
+     * @return the creation date of this release.
+     * @throws IllegalAccessException
+     * @see #getPublicationDate()
+     */
+    @GitHubAccessPoint(path = "@created_at", type = Date.class, requiresAccessToken = false)
+    public Date getCreationDate() throws IllegalAccessException {
+        return getDate("created_at", false);
+    }
+
+    /**
+     * Returns the publication date of this release.
+     * @return the publication date of this release.
+     * @throws IllegalAccessException
+     * @see #getCreationDate()
+     */
+    @GitHubAccessPoint(path = "@published_at", type = Date.class, requiresAccessToken = false)
+    public Date getPublicationDate() throws IllegalAccessException {
+        return getDate("published_at", false);
+    }
+
+    /**
+     * Returns the content of this release's notes.
+     * @return the content of this release's notes.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@body", type = String.class, requiresAccessToken = false)
+    public String getBody() throws IllegalAccessException {
+        return getString("body", false);
+    }
+
+    /**
+     * Returns the author of this release.
+     * @return the author of this release.
+     * @throws IllegalAccessException
+     */
+    @GitHubAccessPoint(path = "@author", type = GitHubUser.class, requiresAccessToken = false)
+    public GitHubUser getAuthor() throws IllegalAccessException {
+        JsonElement element = getResponse(false);
+
+        if (element == null) {
+            throw new IllegalAccessException("Could not connect to '" + getURL() + "'");
+        }
+        JsonObject response = element.getAsJsonObject();
+
+        return isInvalid(response, "author") ? null: new GitHubUser(api, response.get("author").getAsJsonObject().get("login").getAsString(), response.get("author").getAsJsonObject());
+    }
+}

--- a/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRelease.java
+++ b/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRelease.java
@@ -15,12 +15,12 @@ import java.util.Date;
  */
 public class GitHubRelease extends GitHubObject {
 
-    public GitHubRelease(GitHubWebAPI api, GitHubObject parent, int id) {
-        super(api, parent, "/releases/" + id);
+    public GitHubRelease(GitHubWebAPI api, GitHubRepository repo, int id) {
+        super(api, repo, "/releases/" + id);
     }
 
-    public GitHubRelease(GitHubWebAPI api, GitHubObject parent, int id, JsonElement response) {
-        super(api, parent, "/releases/" + id);
+    public GitHubRelease(GitHubWebAPI api, GitHubRepository repo, int id, JsonElement response) {
+        super(api, repo, "/releases/" + id);
 
         this.minimal = response;
     }

--- a/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRepository.java
+++ b/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRepository.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -1129,4 +1130,33 @@ public class GitHubRepository extends UniqueGitHubObject {
 		
 		return isInvalid(response, "license") ? null: new GitHubLicense(api, response.get("license").getAsJsonObject().get("key").getAsString(), response.get("license").getAsJsonObject());
 	}
+
+    /**
+     * Returns a list of thirty of the latest releases of this repository.
+     * The GitHub API does not return all the releases available on a repository, and the number of releases returned by this call might change in the future.
+     * @return a list of the latest releases of this repository.
+     * @throws IllegalAccessException
+     * @since 1.3.4
+     */
+	@GitHubAccessPoint(path = "/releases", type = GitHubRelease.class, requiresAccessToken = false)
+	public List<GitHubRelease> getReleases() throws IllegalAccessException {
+        GitHubObject releases = new GitHubObject(api, this, "/releases");
+        JsonElement response = releases.getResponse(true);
+
+        if (response == null) {
+            throw new IllegalAccessException("Could not connect to '" + getURL() + "'");
+        }
+
+        List<GitHubRelease> list = new LinkedList<>();
+        JsonArray array = response.getAsJsonArray();
+
+        for (int i = 0; i < array.size(); i++) {
+            JsonObject object = array.get(i).getAsJsonObject();
+
+            GitHubRelease release = new GitHubRelease(api, this, object.get("id").getAsInt(), object);
+            list.add(release);
+        }
+
+        return list;
+    }
 }

--- a/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRepository.java
+++ b/src/io/github/TheBusyBiscuit/GitHubWebAPI4Java/objects/repositories/GitHubRepository.java
@@ -1132,9 +1132,8 @@ public class GitHubRepository extends UniqueGitHubObject {
 	}
 
     /**
-     * Returns a list of thirty of the latest releases of this repository.
-     * The GitHub API does not return all the releases available on a repository, and the number of releases returned by this call might change in the future.
-     * @return a list of the latest releases of this repository.
+     * Returns a list of the releases of this repository.
+     * @return a list of the releases of this repository.
      * @throws IllegalAccessException
      * @since 1.3.4
      */


### PR DESCRIPTION
Updated the version to 1.3.4.
Implemented API to get the contents of a repository's releases.
* GitHubRepository#getReleases();
* GitHubRelease